### PR TITLE
JAMES-1615 Allow ResourceLocator.get to throw Exception and not only …

### DIFF
--- a/mailet/src/main/java/org/apache/jsieve/mailet/ResourceLocator.java
+++ b/mailet/src/main/java/org/apache/jsieve/mailet/ResourceLocator.java
@@ -18,7 +18,6 @@
  ****************************************************************/
 package org.apache.jsieve.mailet;
 
-import java.io.IOException;
 import java.io.InputStream;
 
 /**
@@ -60,7 +59,7 @@ public interface ResourceLocator {
      * GET verb locates and loads a resource. 
      * @param uri identifies the Sieve script 
      * @return not null
-     * @throws IOException when the resource cannot be located
+     * @throws Exception when the resource cannot be located
      */
-    public InputStream get(String uri) throws IOException;
+    InputStream get(String uri) throws Exception;
 }


### PR DESCRIPTION
A little change that makes it way pretier in JAMES code.

By the way, the ResourceLocator hide a specific implementation for locating user active script. It should not be bound to a specific exception.