### PR TITLE
Jsieve 73 - Sieve body extension

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -75,6 +75,11 @@
             <artifactId>${javax.activation.artifactId}</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/core/src/main/java/org/apache/jsieve/mail/MailAdapter.java
+++ b/core/src/main/java/org/apache/jsieve/mail/MailAdapter.java
@@ -170,12 +170,35 @@ public interface MailAdapter {
     /**
      * Is the given phrase found in the body text of this mail?
      * This search should be case insensitive.
-     * @param phraseCaseInsensitive the phrase to search
+     * @param phrasesCaseInsensitive the phrases to search
      * @return true when the mail has a textual body and contains the phrase
      * (case insensitive), false otherwise
      * @throws SieveMailException when the search cannot be completed
      */
-    public boolean isInBodyText(final String phraseCaseInsensitive) throws SieveMailException;
+    public boolean isInBodyText(final List<String> phrasesCaseInsensitive) throws SieveMailException;
+
+
+    /**
+     * Is the given phrase found in the body raw of this mail?
+     * This search should be case insensitive and the mail should not be decoded.
+     * @param phrasesCaseInsensitive the phrases to search
+     * @return true when the mail has a textual body and contains the phrase
+     * (case insensitive), false otherwise
+     * @throws SieveMailException when the search cannot be completed
+     */
+    public boolean isInBodyRaw(final List<String> phrasesCaseInsensitive) throws SieveMailException;
+
+
+    /**
+     * Is the given phrase found in the body contents of the specified content types of this mail?
+     * This search should be case insensitive.
+     * @param contentTypes Content types of the body parts we should search into.
+     * @param phrasesCaseInsensitive the phrases to search
+     * @return true when the mail has a textual body and contains the phrase
+     * (case insensitive), false otherwise
+     * @throws SieveMailException when the search cannot be completed
+     */
+    public boolean isInBodyContent(final List<String> contentTypes, final List<String> phrasesCaseInsensitive) throws SieveMailException;
     
     /**
      * <p>

--- a/core/src/test/java/org/apache/jsieve/util/check/ScriptCheckMailAdapter.java
+++ b/core/src/test/java/org/apache/jsieve/util/check/ScriptCheckMailAdapter.java
@@ -244,18 +244,16 @@ public class ScriptCheckMailAdapter implements MailAdapter {
         return result;
     }
 
-    public boolean isInBodyText(String phraseCaseInsensitive) throws SieveMailException {
-        boolean result = false;
-        if (mail != null) {
-            try {
-                result = mail.getContent().toString().toLowerCase().contains(phraseCaseInsensitive);
-            } catch (MessagingException e) {
-                throw new SieveMailException(e);
-            } catch (IOException e) {
-                throw new SieveMailException(e);
-            }
-        }
-        return result;
+    public boolean isInBodyText(List<String> phrasesCaseInsensitive) throws SieveMailException {
+        throw new SieveMailException("Not yet implemented");
+    }
+
+    public boolean isInBodyRaw(List<String> phrasesCaseInsensitive) throws SieveMailException {
+        throw new SieveMailException("Not yet implemented");
+    }
+
+    public boolean isInBodyContent(List<String> contentTypes, List<String> phrasesCaseInsensitive) throws SieveMailException {
+        throw new SieveMailException("Not yet implemented");
     }
 
     public Address[] parseAddresses(String headerName)

--- a/core/src/test/java/org/apache/jsieve/utils/SieveMailAdapter.java
+++ b/core/src/test/java/org/apache/jsieve/utils/SieveMailAdapter.java
@@ -270,14 +270,30 @@ public class SieveMailAdapter implements MailAdapter {
         }
     }
 
-    public boolean isInBodyText(String phraseCaseInsensitive) throws SieveMailException {
+    @Override
+    public boolean isInBodyText(List<String> phrasesCaseInsensitive) throws SieveMailException {
         try {
-            return contentAsText().contains(phraseCaseInsensitive.toLowerCase());
+            for (String phrase : phrasesCaseInsensitive) {
+                if (contentAsText().contains(phrase.toLowerCase())) {
+                    return true;
+                }
+            }
+            return false;
         } catch (MessagingException ex) {
             throw new SieveMailException(ex);
         } catch (IOException ex) {
             throw new SieveMailException(ex);
         }
+    }
+
+    @Override
+    public boolean isInBodyRaw(List<String> phrasesCaseInsensitive) throws SieveMailException {
+        throw new SieveMailException("Not yet implemented");
+    }
+
+    @Override
+    public boolean isInBodyContent(List<String> contentTypes, List<String> phrasesCaseInsensitive) throws SieveMailException {
+        throw new SieveMailException("Not yet implemented");
     }
 
     private String contentAsText() throws IOException, MessagingException {

--- a/mailet/pom.xml
+++ b/mailet/pom.xml
@@ -71,10 +71,18 @@
             <groupId>org.apache.james</groupId>
             <artifactId>apache-mime4j-dom</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.apache.james</groupId>
+            <artifactId>apache-mime4j-james-utils</artifactId>
+        </dependency>
 
         <dependency>
             <groupId>commons-logging</groupId>
             <artifactId>commons-logging</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.google.guava</groupId>
+            <artifactId>guava</artifactId>
         </dependency>
 
         <dependency>

--- a/mailet/src/main/java/org/apache/jsieve/mailet/SieveMailAdapter.java
+++ b/mailet/src/main/java/org/apache/jsieve/mailet/SieveMailAdapter.java
@@ -445,5 +445,17 @@ public class SieveMailAdapter implements MailAdapter, EnvelopeAccessors, ActionC
         }
     }
 
+    public boolean isInBodyText(List<String> phrasesCaseInsensitive) throws SieveMailException {
+        throw new SieveMailException("Not yet implemented");
+    }
+
+    public boolean isInBodyRaw(List<String> phrasesCaseInsensitive) throws SieveMailException {
+        throw new SieveMailException("Not yet implemented");
+    }
+
+    public boolean isInBodyContent(List<String> contentTypes, List<String> phrasesCaseInsensitive) throws SieveMailException {
+        throw new SieveMailException("Not yet implemented");
+    }
+
     public void setContext(SieveContext context) {}
 }

--- a/pom.xml
+++ b/pom.xml
@@ -87,6 +87,8 @@
         <geronimo-activation.version>1.1</geronimo-activation.version>
         <geronimo-javamail.version>1.8.3</geronimo-javamail.version>
         <commons-io.version>2.1</commons-io.version>
+        <mockito-core.version>1.9.0</mockito-core.version>
+        <assertj.version>1.7.1</assertj.version>
     </properties>
 
     <dependencyManagement>
@@ -212,6 +214,12 @@
                 <groupId>org.apache.geronimo.javamail</groupId>
                 <artifactId>geronimo-javamail_1.4_mail</artifactId>
                 <version>${geronimo-javamail.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.mockito</groupId>
+                <artifactId>mockito-core</artifactId>
+                <version>${mockito-core.version}</version>
+                <scope>test</scope>
             </dependency>
         </dependencies>
     </dependencyManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -89,6 +89,7 @@
         <commons-io.version>2.1</commons-io.version>
         <mockito-core.version>1.9.0</mockito-core.version>
         <assertj.version>1.7.1</assertj.version>
+        <guava.version>16.0</guava.version>
     </properties>
 
     <dependencyManagement>
@@ -148,6 +149,16 @@
                 <groupId>org.apache.james</groupId>
                 <artifactId>apache-mime4j-dom</artifactId>
                 <version>${mime4j.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.james</groupId>
+                <artifactId>apache-mime4j-james-utils</artifactId>
+                <version>${mime4j.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>com.google.guava</groupId>
+                <artifactId>guava</artifactId>
+                <version>${guava.version}</version>
             </dependency>
             <dependency>
                 <groupId>commons-logging</groupId>

--- a/util/src/main/java/org/apache/jsieve/util/check/ScriptCheckMailAdapter.java
+++ b/util/src/main/java/org/apache/jsieve/util/check/ScriptCheckMailAdapter.java
@@ -275,18 +275,16 @@ public class ScriptCheckMailAdapter implements MailAdapter {
         }
     }
 
-    public boolean isInBodyText(String phraseCaseInsensitive) throws SieveMailException {
-        boolean result = false;
-        if (mail != null) {
-            try {
-                result = mail.getContent().toString().toLowerCase().contains(phraseCaseInsensitive);
-            } catch (MessagingException e) {
-                throw new SieveMailException(e);
-            } catch (IOException e) {
-                throw new SieveMailException(e);
-            }
-        }
-        return result;
+    public boolean isInBodyText(List<String> phrasesCaseInsensitive) throws SieveMailException {
+        throw new SieveMailException("Not yet implemented");
+    }
+
+    public boolean isInBodyRaw(List<String> phrasesCaseInsensitive) throws SieveMailException {
+        throw new SieveMailException("Not yet implemented");
+    }
+
+    public boolean isInBodyContent(List<String> contentTypes, List<String> phrasesCaseInsensitive) throws SieveMailException {
+        throw new SieveMailException("Not yet implemented");
     }
 
     public void setContext(SieveContext context) {


### PR DESCRIPTION
This PR propose patchs so that Jsieve implements RFC 5173 : Sieve Body extension.

Note that matching feature is achived threw the tools used by the IMAP search feature without indexing. (It was a little expended so that it can search the raw message and filter content by mime type).

**There is a new dependency between mailbox/store and sieve/mailet**. I don't think this is the better way to do it. I think we need to relocate MessageSearcher to some other projects. Don't hesitate to tell me your thoghts about that.