### PR TITLE
Always do unfold headers to fix long header test match

### DIFF
--- a/util/src/main/java/org/apache/jsieve/util/check/ScriptCheckMailAdapter.java
+++ b/util/src/main/java/org/apache/jsieve/util/check/ScriptCheckMailAdapter.java
@@ -28,12 +28,12 @@ import org.apache.jsieve.mail.SieveMailException;
 import org.apache.jsieve.parser.address.SieveAddressBuilder;
 import org.apache.jsieve.parser.generated.address.ParseException;
 
+import javax.mail.internet.MimeUtility;
 import javax.mail.Header;
 import javax.mail.Message;
 import javax.mail.MessagingException;
 import java.io.IOException;
 import java.util.*;
-import javax.mail.internet.MimeUtility;
 import java.io.UnsupportedEncodingException;
 
 /**
@@ -139,10 +139,11 @@ public class ScriptCheckMailAdapter implements MailAdapter {
             try {
                 String[] values = mail.getHeader(name);
                 if (values != null) {
-                    //We need to do unfold headers here
+                    // We need to do unfold headers + decoding here
                     result = new LinkedList<String>();
-                    for (String value: values)
+                    for (String value: values) {
                         result.add(MimeUtility.decodeText(MimeUtility.unfold(value)));
+                    }
                 }
             } catch (MessagingException e) {
                 throw new SieveMailException(e);

--- a/util/src/main/java/org/apache/jsieve/util/check/ScriptCheckMailAdapter.java
+++ b/util/src/main/java/org/apache/jsieve/util/check/ScriptCheckMailAdapter.java
@@ -33,6 +33,7 @@ import javax.mail.Message;
 import javax.mail.MessagingException;
 import java.io.IOException;
 import java.util.*;
+import javax.mail.internet.MimeUtility;
 
 /**
  * Checks script execution for an email. The wrapped email is set by called
@@ -137,7 +138,10 @@ public class ScriptCheckMailAdapter implements MailAdapter {
             try {
                 String[] values = mail.getHeader(name);
                 if (values != null) {
-                    result = Arrays.asList(values);
+                    //We need to do unfold headers here
+                    result = new LinkedList<String>();
+                    for (String value: values)
+                        result.add(MimeUtility.unfold(value));
                 }
             } catch (MessagingException e) {
                 throw new SieveMailException(e);

--- a/util/src/main/java/org/apache/jsieve/util/check/ScriptCheckMailAdapter.java
+++ b/util/src/main/java/org/apache/jsieve/util/check/ScriptCheckMailAdapter.java
@@ -265,7 +265,7 @@ public class ScriptCheckMailAdapter implements MailAdapter {
                 final Header header = (Header) en.nextElement();
                 final String name = header.getName();
                 if (name.trim().equalsIgnoreCase(headerName)) {
-                    builder.addAddresses(header.getValue());
+                    builder.addAddresses(MimeUtility.unfold(header.getValue()));
                 }
             }
 

--- a/util/src/main/java/org/apache/jsieve/util/check/ScriptCheckMailAdapter.java
+++ b/util/src/main/java/org/apache/jsieve/util/check/ScriptCheckMailAdapter.java
@@ -34,6 +34,7 @@ import javax.mail.MessagingException;
 import java.io.IOException;
 import java.util.*;
 import javax.mail.internet.MimeUtility;
+import java.io.UnsupportedEncodingException;
 
 /**
  * Checks script execution for an email. The wrapped email is set by called
@@ -141,9 +142,11 @@ public class ScriptCheckMailAdapter implements MailAdapter {
                     //We need to do unfold headers here
                     result = new LinkedList<String>();
                     for (String value: values)
-                        result.add(MimeUtility.unfold(value));
+                        result.add(MimeUtility.decodeText(MimeUtility.unfold(value)));
                 }
             } catch (MessagingException e) {
+                throw new SieveMailException(e);
+            } catch (UnsupportedEncodingException e) {
                 throw new SieveMailException(e);
             }
         }
@@ -265,7 +268,7 @@ public class ScriptCheckMailAdapter implements MailAdapter {
                 final Header header = (Header) en.nextElement();
                 final String name = header.getName();
                 if (name.trim().equalsIgnoreCase(headerName)) {
-                    builder.addAddresses(MimeUtility.unfold(header.getValue()));
+                    builder.addAddresses(MimeUtility.decodeText(MimeUtility.unfold(header.getValue())));
                 }
             }
 
@@ -273,6 +276,8 @@ public class ScriptCheckMailAdapter implements MailAdapter {
             return results;
 
         } catch (MessagingException ex) {
+            throw new SieveMailException(ex);
+        } catch (UnsupportedEncodingException ex) {
             throw new SieveMailException(ex);
         } catch (ParseException ex) {
             throw new SieveMailException(ex);

--- a/util/src/test/java/org/apache/jsieve/util/HeaderMatchingTest.java
+++ b/util/src/test/java/org/apache/jsieve/util/HeaderMatchingTest.java
@@ -1,0 +1,78 @@
+package org.apache.jsieve.util;
+
+import java.io.ByteArrayInputStream;
+import java.io.File;
+import java.io.FileInputStream;
+
+import javax.mail.Session;
+import javax.mail.internet.MimeMessage;
+
+import org.apache.jsieve.ConfigurationManager;
+import org.apache.jsieve.SieveFactory;
+import org.apache.jsieve.mail.ActionRedirect;
+import org.apache.jsieve.parser.generated.Node;
+import org.apache.jsieve.util.check.ScriptCheckMailAdapter;
+
+import junit.framework.TestCase;
+
+public class HeaderMatchingTest extends TestCase {
+
+	private SieveFactory sieveFactory;
+
+	static String foldedSubjectMatch = "if header :is \"subject\" \"Test with long long long long long long long long long "
+			+ "long long long long long long long long long long long very very long folded subject email\" { "
+			+ "redirect \"test@test.test\";" + "}";
+	
+	static String encodedSubjectMatch = "if header :is \"subject\" \"Test però £ ù €\" { "
+			+ "redirect \"test@test.test\";" + "}";
+
+	@Override
+	protected void setUp() throws Exception {
+		this.sieveFactory = new ConfigurationManager().build();
+		super.setUp();
+	}
+
+	public void testFoldedHeader() throws Exception {
+
+		// Load test message file
+		File file = new File(this.getClass().getResource("FoldedSubjectEmail.eml").getFile());
+		MimeMessage message = new MimeMessage(Session.getDefaultInstance(System.getProperties()),
+				new FileInputStream(file));
+
+		// Associate it to the adapter
+		ScriptCheckMailAdapter adapter = new ScriptCheckMailAdapter();
+		adapter.setMail(message);
+
+		// Parse sieve script
+		Node parsedSieve = sieveFactory.parse(new ByteArrayInputStream(foldedSubjectMatch.getBytes("UTF-8")));
+
+		// Evaluate the script against the message
+		sieveFactory.evaluate(adapter, parsedSieve);
+
+		// Test is OK if we have the "redirect" action
+		assertTrue( adapter.getActions().get(0) instanceof ActionRedirect);
+
+	}
+
+	public void testEncodedHeader() throws Exception {
+
+		// Load test message file
+		File file = new File(this.getClass().getResource("EncodedSubjectEmail.eml").getFile());
+		MimeMessage message = new MimeMessage(Session.getDefaultInstance(System.getProperties()),
+				new FileInputStream(file));
+
+		// Associate it to the adapter
+		ScriptCheckMailAdapter adapter = new ScriptCheckMailAdapter();
+		adapter.setMail(message);
+
+		// Parse sieve script
+		Node parsedSieve = sieveFactory.parse(new ByteArrayInputStream(encodedSubjectMatch.getBytes("UTF-8")));
+
+		// Evaluate the script against the message
+		sieveFactory.evaluate(adapter, parsedSieve);
+
+		// Test is OK if we have the "redirect" action
+		assertTrue(adapter.getActions().get(0) instanceof ActionRedirect);
+
+	}
+}

--- a/util/src/test/resources/org/apache/jsieve/util/EncodedSubjectEmail.eml
+++ b/util/src/test/resources/org/apache/jsieve/util/EncodedSubjectEmail.eml
@@ -1,0 +1,34 @@
+Return-Path: <depetrini@libero.it>
+Received: from libero.it (10.248.25.145) by cpms5.iol.local (8.6.145)
+        id 573CB16204A62C80 for depetrini@libero.it; Wed, 4 Jan 2017 22:42:32 +0100
+Received: from [10.0.2.15] ([2.233.76.134])
+	by smtp-17.iol.local with SMTP
+	id OtKKcttnC4PYNOtKKcNG5e; Wed, 04 Jan 2017 22:42:32 +0100
+x-libjamoibt: 1601
+DKIM-Signature: v=1; a=rsa-sha256; c=relaxed/relaxed; d=libero.it; s=s2014;
+	t=1483566152; bh=kkw4KHbCvOqwySQD7LgSczFcQr3K0V6ZGz9ZG2z81Jk=;
+	h=To:From:Subject:Date;
+	b=EypoemMZLRRgr7/boGpuCQfuvkh5cT2sEB/C9Cmzl1PpwS97GGakoYzkAsyLevR/P
+	 5l4Y89lDUB/CKGGHPr/gZQf0ua//zt605Exbcy+xMO5xdxyliaFqRgwL5B50UkZaov
+	 Qz21lbS/fVQOYYAvoQVZobXqoufjl4F7tKj2+1w6v2USAxf1EXqfLuqm2msIrVtXN7
+	 N1nebgQNw/6Cb1n63Zlf2GTx2ktGSlRFeIGKeWJyy+hyst48z7tg/KOfq3O6oZLH5G
+	 Vzh7enSOfnPqLquK3PynVIBjzulZqrnaqTxtpaIDkVmZMyJr6zj/V52MPCjN9+c9Qe
+	 weqPot9d6oAJg==
+X-CNFS-Analysis: v=2.2 cv=T7n8d7CQ c=1 sm=1 tr=0
+ a=G9QXGcRg7K4cpRF729+Nrw==:117 a=G9QXGcRg7K4cpRF729+Nrw==:17
+ a=Q9fys5e9bTEA:10 a=ceSYFpfoL52z1fb7cHMA:9 a=PUjeQqilurYA:10
+To: Daniele Depetrini <depetrini@libero.it>
+From: Daniele Depetrini <depetrini@libero.it>
+Subject: =?UTF-8?B?VGVzdCBwZXLDsiDCoyDDuSDigqw=?=
+Message-ID: <2325dfff-55af-9391-6a91-1213426e381e@libero.it>
+Date: Wed, 4 Jan 2017 22:42:32 +0100
+User-Agent: Mozilla/5.0 (X11; Linux x86_64; rv:45.0) Gecko/20100101
+ Thunderbird/45.5.1
+MIME-Version: 1.0
+Content-Type: text/plain; charset=iso-8859-15
+Content-Transfer-Encoding: 7bit
+X-CMAE-Envelope: MS4wfMU/gh3tvj2kO2hDEIVipd/xRev1VFUnHfvEYgchLMl2loW6QpFqiih+lQzTM7i1KbfYPAGnLbhv/obHpTHh85U0WCedV9kT2AcZOt5WiE3pCBcZGKjr
+ 3NqeCElOLtIXiKf7ijVMH4NeFO0Hk+h+z1Q0ofMRsg7/k/MnTvM6DAI+
+
+frff
+

--- a/util/src/test/resources/org/apache/jsieve/util/FoldedSubjectEmail.eml
+++ b/util/src/test/resources/org/apache/jsieve/util/FoldedSubjectEmail.eml
@@ -1,0 +1,35 @@
+Return-Path: <depetrini@libero.it>
+Received: from libero.it (10.248.25.145) by cpms5.iol.local (8.6.145)
+        id 573CB16204A5554D for depetrini@libero.it; Wed, 4 Jan 2017 17:17:38 +0100
+Received: from [10.0.2.15] ([2.233.76.134])
+	by smtp-17.iol.local with SMTP
+	id OoFucrRAR4PYNOoFucLlcR; Wed, 04 Jan 2017 17:17:38 +0100
+x-libjamoibt: 1601
+DKIM-Signature: v=1; a=rsa-sha256; c=relaxed/relaxed; d=libero.it; s=s2014;
+	t=1483546658; bh=3i4UmafHd35a6hS/1SXIZlapveu4D3wW6pVwIcNbhC4=;
+	h=To:From:Subject:Date;
+	b=DKEtlURZR5P0VW1Cw39Gxn38ID67WAmp7U6HJvpPwoDSHZP8uRex/r+vHF+Lt0HIH
+	 jKAmrbc3P2KQWchdFliFWy3+zTcXgbiznD6EHGLcOLDhckjf8ndCR8VRJuyCSYv0LR
+	 uu1ocMlNKs/HZfmCAfDO/Q+e4hQOw9MKdNBtE9cv5a6dmRnkYaAq/c1wp8p5/l3eXp
+	 ZWIQTptRt8PGzeLiURQKyKSYA6rU8Tkc3k/wBupPChZ3CDB5Lk3LfVFXVHmAqO3xB1
+	 kQ1znbMhzqyr6jQUM+VAsjUIEQtgA3HKt3LGI//sjLFjUx5PFh9w8qq+xhSPiCI0j5
+	 Loppx+rqjqyIg==
+X-CNFS-Analysis: v=2.2 cv=T7n8d7CQ c=1 sm=1 tr=0
+ a=G9QXGcRg7K4cpRF729+Nrw==:117 a=G9QXGcRg7K4cpRF729+Nrw==:17
+ a=Q9fys5e9bTEA:10 a=ib5foG0-psVtnUUdY2IA:9 a=PUjeQqilurYA:10
+To: Daniele Depetrini <depetrini@libero.it>
+From: Daniele Depetrini <depetrini@libero.it>
+Subject: Test with long long long long long long long long long long long long
+ long long long long long long long long very very long folded subject email
+Message-ID: <4cb56dec-b7a4-8476-0327-6a1b52963414@libero.it>
+Date: Wed, 4 Jan 2017 17:17:38 +0100
+User-Agent: Mozilla/5.0 (X11; Linux x86_64; rv:45.0) Gecko/20100101
+ Thunderbird/45.5.1
+MIME-Version: 1.0
+Content-Type: text/plain; charset=iso-8859-15
+Content-Transfer-Encoding: 7bit
+X-CMAE-Envelope: MS4wfB4u3A7IiWTsTzhiabOaYYCLyYIzI3nH7FIzGINMBCkWn6tKtl17w9idyqbRrL2uU+XegioppOyxJFqa/qJq0VardrD5AiOO3s80f1oIc5FEoUksHmBc
+ D4lXmVUmRN8PafAWARdYg1W9+6m/kQDMCIQGb9hauyYJSf6SXah7sCMM
+
+asdfasdfa
+


### PR DESCRIPTION
This patch will fix (at least) header test with "matches" criteria in case of long (folded) headers
