### PR TITLE
JSIEVE-107

### DIFF
--- a/util/pom.xml
+++ b/util/pom.xml
@@ -52,6 +52,13 @@
         </dependency>
 
         <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
+            <version>${assertj.version}</version>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
             <groupId>commons-logging</groupId>
             <artifactId>commons-logging</artifactId>
         </dependency>

--- a/util/src/main/java/org/apache/jsieve/util/check/ScriptCheckMailAdapter.java
+++ b/util/src/main/java/org/apache/jsieve/util/check/ScriptCheckMailAdapter.java
@@ -19,6 +19,18 @@
 
 package org.apache.jsieve.util.check;
 
+import java.io.UnsupportedEncodingException;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Enumeration;
+import java.util.LinkedList;
+import java.util.List;
+
+import javax.mail.Header;
+import javax.mail.Message;
+import javax.mail.MessagingException;
+import javax.mail.internet.MimeUtility;
+
 import org.apache.jsieve.SieveContext;
 import org.apache.jsieve.exception.SieveException;
 import org.apache.jsieve.mail.Action;
@@ -27,14 +39,6 @@ import org.apache.jsieve.mail.MailUtils;
 import org.apache.jsieve.mail.SieveMailException;
 import org.apache.jsieve.parser.address.SieveAddressBuilder;
 import org.apache.jsieve.parser.generated.address.ParseException;
-
-import javax.mail.internet.MimeUtility;
-import javax.mail.Header;
-import javax.mail.Message;
-import javax.mail.MessagingException;
-import java.io.IOException;
-import java.util.*;
-import java.io.UnsupportedEncodingException;
 
 /**
  * Checks script execution for an email. The wrapped email is set by called
@@ -168,7 +172,7 @@ public class ScriptCheckMailAdapter implements MailAdapter {
         if (mail != null) {
             try {
                 results = new ArrayList<String>();
-                for (final Enumeration en = mail.getAllHeaders(); en
+                for (final Enumeration<?> en = mail.getAllHeaders(); en
                         .hasMoreElements(); ) {
                     final Header header = (Header) en.nextElement();
                     final String name = header.getName();
@@ -265,7 +269,7 @@ public class ScriptCheckMailAdapter implements MailAdapter {
         try {
             final SieveAddressBuilder builder = new SieveAddressBuilder();
 
-            for (Enumeration en = message.getAllHeaders(); en.hasMoreElements(); ) {
+            for (Enumeration<?> en = message.getAllHeaders(); en.hasMoreElements(); ) {
                 final Header header = (Header) en.nextElement();
                 final String name = header.getName();
                 if (name.trim().equalsIgnoreCase(headerName)) {

--- a/util/src/main/java/org/apache/jsieve/util/check/ScriptCheckMailAdapter.java
+++ b/util/src/main/java/org/apache/jsieve/util/check/ScriptCheckMailAdapter.java
@@ -28,12 +28,12 @@ import org.apache.jsieve.mail.SieveMailException;
 import org.apache.jsieve.parser.address.SieveAddressBuilder;
 import org.apache.jsieve.parser.generated.address.ParseException;
 
+import javax.mail.internet.MimeUtility;
 import javax.mail.Header;
 import javax.mail.Message;
 import javax.mail.MessagingException;
 import java.io.IOException;
 import java.util.*;
-import javax.mail.internet.MimeUtility;
 import java.io.UnsupportedEncodingException;
 
 /**
@@ -139,10 +139,11 @@ public class ScriptCheckMailAdapter implements MailAdapter {
             try {
                 String[] values = mail.getHeader(name);
                 if (values != null) {
-                    //We need to do unfold headers here
+                    // We need to do unfold headers + decoding here
                     result = new LinkedList<String>();
-                    for (String value: values)
+                    for (String value: values) {
                         result.add(MimeUtility.decodeText(MimeUtility.unfold(value)));
+                    }
                 }
             } catch (MessagingException e) {
                 throw new SieveMailException(e);

--- a/util/src/main/java/org/apache/jsieve/util/check/ScriptCheckMailAdapter.java
+++ b/util/src/main/java/org/apache/jsieve/util/check/ScriptCheckMailAdapter.java
@@ -33,6 +33,7 @@ import javax.mail.Message;
 import javax.mail.MessagingException;
 import java.io.IOException;
 import java.util.*;
+import javax.mail.internet.MimeUtility;
 
 /**
  * Checks script execution for an email. The wrapped email is set by called
@@ -137,7 +138,10 @@ public class ScriptCheckMailAdapter implements MailAdapter {
             try {
                 String[] values = mail.getHeader(name);
                 if (values != null) {
-                    result = Arrays.asList(values);
+                    //We need to do unfold headers here
+                    result = new LinkedList<String>();
+                    for (String value: values)
+                        result.add(MimeUtility.unfold(value));
                 }
             } catch (MessagingException e) {
                 throw new SieveMailException(e);

--- a/util/src/main/java/org/apache/jsieve/util/check/ScriptCheckMailAdapter.java
+++ b/util/src/main/java/org/apache/jsieve/util/check/ScriptCheckMailAdapter.java
@@ -265,7 +265,7 @@ public class ScriptCheckMailAdapter implements MailAdapter {
                 final Header header = (Header) en.nextElement();
                 final String name = header.getName();
                 if (name.trim().equalsIgnoreCase(headerName)) {
-                    builder.addAddresses(header.getValue());
+                    builder.addAddresses(MimeUtility.unfold(header.getValue()));
                 }
             }
 

--- a/util/src/main/java/org/apache/jsieve/util/check/ScriptCheckMailAdapter.java
+++ b/util/src/main/java/org/apache/jsieve/util/check/ScriptCheckMailAdapter.java
@@ -34,6 +34,7 @@ import javax.mail.MessagingException;
 import java.io.IOException;
 import java.util.*;
 import javax.mail.internet.MimeUtility;
+import java.io.UnsupportedEncodingException;
 
 /**
  * Checks script execution for an email. The wrapped email is set by called
@@ -141,9 +142,11 @@ public class ScriptCheckMailAdapter implements MailAdapter {
                     //We need to do unfold headers here
                     result = new LinkedList<String>();
                     for (String value: values)
-                        result.add(MimeUtility.unfold(value));
+                        result.add(MimeUtility.decodeText(MimeUtility.unfold(value)));
                 }
             } catch (MessagingException e) {
+                throw new SieveMailException(e);
+            } catch (UnsupportedEncodingException e) {
                 throw new SieveMailException(e);
             }
         }
@@ -265,7 +268,7 @@ public class ScriptCheckMailAdapter implements MailAdapter {
                 final Header header = (Header) en.nextElement();
                 final String name = header.getName();
                 if (name.trim().equalsIgnoreCase(headerName)) {
-                    builder.addAddresses(MimeUtility.unfold(header.getValue()));
+                    builder.addAddresses(MimeUtility.decodeText(MimeUtility.unfold(header.getValue())));
                 }
             }
 
@@ -273,6 +276,8 @@ public class ScriptCheckMailAdapter implements MailAdapter {
             return results;
 
         } catch (MessagingException ex) {
+            throw new SieveMailException(ex);
+        } catch (UnsupportedEncodingException ex) {
             throw new SieveMailException(ex);
         } catch (ParseException ex) {
             throw new SieveMailException(ex);

--- a/util/src/test/java/org/apache/jsieve/util/ScriptCheckMailAdapterTest.java
+++ b/util/src/test/java/org/apache/jsieve/util/ScriptCheckMailAdapterTest.java
@@ -1,0 +1,102 @@
+/****************************************************************
+ * Licensed to the Apache Software Foundation (ASF) under one   *
+ * or more contributor license agreements.  See the NOTICE file *
+ * distributed with this work for additional information        *
+ * regarding copyright ownership.  The ASF licenses this file   *
+ * to you under the Apache License, Version 2.0 (the            *
+ * "License"); you may not use this file except in compliance   *
+ * with the License.  You may obtain a copy of the License at   *
+ *                                                              *
+ *   http://www.apache.org/licenses/LICENSE-2.0                 *
+ *                                                              *
+ * Unless required by applicable law or agreed to in writing,   *
+ * software distributed under the License is distributed on an  *
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY       *
+ * KIND, either express or implied.  See the License for the    *
+ * specific language governing permissions and limitations      *
+ * under the License.                                           *
+ ****************************************************************/
+package org.apache.jsieve.util;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.ByteArrayInputStream;
+
+import javax.mail.Session;
+import javax.mail.internet.MimeMessage;
+
+import org.apache.jsieve.ConfigurationManager;
+import org.apache.jsieve.SieveFactory;
+import org.apache.jsieve.mail.ActionRedirect;
+import org.apache.jsieve.parser.generated.Node;
+import org.apache.jsieve.util.check.ScriptCheckMailAdapter;
+import org.junit.Before;
+import org.junit.Test;
+
+public class ScriptCheckMailAdapterTest {
+
+    private static final String FOLDED_SUBJECT_MATCH = "if header :is \"subject\" \"Test with long long long long long long long long long "
+            + "long long long long long long long long long long long very very long folded subject email\" { "
+            + "redirect \"test@test.test\";" + "}";
+    
+    private static final String ENCODED_SUBJECT_MATCH = "if header :is \"subject\" \"Test però £ ù €\" { "
+            + "redirect \"test@test.test\";" + "}";
+
+    private SieveFactory sieveFactory;
+
+
+    @Before
+    public void setUp() throws Exception {
+        this.sieveFactory = new ConfigurationManager().build();
+    }
+
+    @Test
+    public void askedActionMustBeExecutedWhenFoldedHeaderMatchs() throws Exception {
+
+        //Given
+        // Load test message file
+        MimeMessage message = new MimeMessage(Session.getDefaultInstance(System.getProperties()),
+                ClassLoader.getSystemResourceAsStream("org/apache/jsieve/util/FoldedSubjectEmail.eml"));
+
+        // Associate it to the adapter
+        ScriptCheckMailAdapter testee = new ScriptCheckMailAdapter();
+        testee.setMail(message);
+
+        //When
+        // Parse sieve script
+        Node parsedSieve = sieveFactory.parse(new ByteArrayInputStream(FOLDED_SUBJECT_MATCH.getBytes("UTF-8")));
+
+        // Evaluate the script against the message
+        sieveFactory.evaluate(testee, parsedSieve);
+
+        //Then
+        // Test is OK if we have the "redirect" action
+        assertThat(testee.getActions()).hasSize(1);
+        assertThat(testee.getActions().get(0)).isInstanceOf(ActionRedirect.class);
+    }
+
+    @Test
+    public void askedActionMustBeExecutedWhenEncodedHeaderMatchs() throws Exception {
+
+        //Given
+        // Load test message file
+        MimeMessage message = new MimeMessage(Session.getDefaultInstance(System.getProperties()),
+                ClassLoader.getSystemResourceAsStream("org/apache/jsieve/util/EncodedSubjectEmail.eml"));
+
+        // Associate it to the adapter
+        ScriptCheckMailAdapter testee = new ScriptCheckMailAdapter();
+        testee.setMail(message);
+
+        //When
+        // Parse sieve script
+        Node parsedSieve = sieveFactory.parse(new ByteArrayInputStream(ENCODED_SUBJECT_MATCH.getBytes("UTF-8")));
+
+        // Evaluate the script against the message
+        sieveFactory.evaluate(testee, parsedSieve);
+
+        //Then
+        // Test is OK if we have the "redirect" action
+        assertThat(testee.getActions()).hasSize(1);
+        assertThat(testee.getActions().get(0)).isInstanceOf(ActionRedirect.class);
+    }
+}

--- a/util/src/test/resources/org/apache/jsieve/util/EncodedSubjectEmail.eml
+++ b/util/src/test/resources/org/apache/jsieve/util/EncodedSubjectEmail.eml
@@ -1,0 +1,12 @@
+Return-Path: <depetrini@libero.it>
+To: Daniele Depetrini <depetrini@libero.it>
+From: Daniele Depetrini <depetrini@libero.it>
+Subject: =?UTF-8?B?VGVzdCBwZXLDsiDCoyDDuSDigqw=?=
+Message-ID: <2325dfff-55af-9391-6a91-1213426e381e@libero.it>
+Date: Wed, 4 Jan 2017 22:42:32 +0100
+MIME-Version: 1.0
+Content-Type: text/plain; charset=iso-8859-15
+Content-Transfer-Encoding: 7bit
+
+frff
+

--- a/util/src/test/resources/org/apache/jsieve/util/FoldedSubjectEmail.eml
+++ b/util/src/test/resources/org/apache/jsieve/util/FoldedSubjectEmail.eml
@@ -1,0 +1,13 @@
+Return-Path: <depetrini@libero.it>
+To: Daniele Depetrini <depetrini@libero.it>
+From: Daniele Depetrini <depetrini@libero.it>
+Subject: Test with long long long long long long long long long long long long
+ long long long long long long long long very very long folded subject email
+Message-ID: <4cb56dec-b7a4-8476-0327-6a1b52963414@libero.it>
+Date: Wed, 4 Jan 2017 17:17:38 +0100
+MIME-Version: 1.0
+Content-Type: text/plain; charset=iso-8859-15
+Content-Transfer-Encoding: 7bit
+
+asdfasdfa
+


### PR DESCRIPTION
Coming from: https://github.com/apache/james-jsieve/pull/12
The unitary test class has been renamed according to good practice and uses now junit framework.