### PR TITLE
JSIEVE-111 libs upgrade

### DIFF
--- a/all/pom.xml
+++ b/all/pom.xml
@@ -54,6 +54,7 @@
         <plugins>
             <plugin>
                 <artifactId>maven-assembly-plugin</artifactId>
+                <version>3.1.1</version>
                 <configuration>
                     <descriptorSourceDirectory>${project.basedir}/src/assemble/</descriptorSourceDirectory>
                     <tarLongFileMode>gnu</tarLongFileMode>
@@ -63,7 +64,7 @@
                         <id>make-assembly</id>
                         <phase>package</phase>
                         <goals>
-                            <goal>attached</goal>
+                            <goal>single</goal>
                         </goals>
                     </execution>
                 </executions>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -69,14 +69,14 @@
         </dependency>
 
         <dependency>
-            <groupId>${javax.mail.groupId}</groupId>
-            <artifactId>${javax.mail.artifactId}</artifactId>
+            <groupId>javax.mail</groupId>
+            <artifactId>mail</artifactId>
             <scope>test</scope>
         </dependency>
 
         <dependency>
-            <groupId>${javax.activation.groupId}</groupId>
-            <artifactId>${javax.activation.artifactId}</artifactId>
+            <groupId>javax.activation</groupId>
+            <artifactId>activation</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -115,7 +115,7 @@
             <plugin>
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>build-helper-maven-plugin</artifactId>
-                <version>1.7</version>
+                <version>3.0.0</version>
                 <executions>
                     <execution>
                         <id>add-source</id>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -63,8 +63,8 @@
         </dependency>
 
         <dependency>
-            <groupId>log4j</groupId>
-            <artifactId>log4j</artifactId>
+            <groupId>org.apache.logging.log4j</groupId>
+            <artifactId>log4j-core</artifactId>
             <scope>test</scope>
         </dependency>
 

--- a/core/src/test/java/org/apache/jsieve/VacationTest.java
+++ b/core/src/test/java/org/apache/jsieve/VacationTest.java
@@ -19,6 +19,12 @@
 
 package org.apache.jsieve;
 
+import static org.mockito.ArgumentMatchers.isNull;
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+
 import org.apache.jsieve.exception.SyntaxException;
 import org.apache.jsieve.mail.ActionKeep;
 import org.apache.jsieve.mail.optional.ActionVacation;
@@ -26,12 +32,6 @@ import org.apache.jsieve.utils.JUnitUtils;
 import org.apache.jsieve.utils.SieveMailAdapter;
 import org.junit.Before;
 import org.junit.Test;
-
-import static org.mockito.Matchers.any;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.verifyNoMoreInteractions;
 
 public class VacationTest {
 
@@ -111,9 +111,10 @@ public class VacationTest {
 
         JUnitUtils.interpret(sieveMailAdapter, script);
 
-        verify(sieveMailAdapter, times(2)).setContext(any(SieveContext.class));
+        verify(sieveMailAdapter).setContext(any(SieveContext.class));
+        verify(sieveMailAdapter).setContext(isNull(SieveContext.class));
         verify(sieveMailAdapter).addAction(ActionVacation.builder().reason("reason").build());
-        verify(sieveMailAdapter, times(2)).addAction(any(ActionKeep.class));
+        verify(sieveMailAdapter).addAction(any(ActionKeep.class));
         verify(sieveMailAdapter).executeActions();
         verifyNoMoreInteractions(sieveMailAdapter);
     }
@@ -124,9 +125,10 @@ public class VacationTest {
 
         JUnitUtils.interpret(sieveMailAdapter, script);
 
-        verify(sieveMailAdapter, times(2)).setContext(any(SieveContext.class));
+        verify(sieveMailAdapter).setContext(any(SieveContext.class));
+        verify(sieveMailAdapter).setContext(isNull(SieveContext.class));
         verify(sieveMailAdapter).addAction(ActionVacation.builder().reason("reason").duration(3).build());
-        verify(sieveMailAdapter, times(2)).addAction(any(ActionKeep.class));
+        verify(sieveMailAdapter).addAction(any(ActionKeep.class));
         verify(sieveMailAdapter).executeActions();
         verifyNoMoreInteractions(sieveMailAdapter);
     }
@@ -137,9 +139,10 @@ public class VacationTest {
 
         JUnitUtils.interpret(sieveMailAdapter, script);
 
-        verify(sieveMailAdapter, times(2)).setContext(any(SieveContext.class));
+        verify(sieveMailAdapter).setContext(any(SieveContext.class));
+        verify(sieveMailAdapter).setContext(isNull(SieveContext.class));
         verify(sieveMailAdapter).addAction(ActionVacation.builder().reason("reason").subject("any").build());
-        verify(sieveMailAdapter, times(2)).addAction(any(ActionKeep.class));
+        verify(sieveMailAdapter).addAction(any(ActionKeep.class));
         verify(sieveMailAdapter).executeActions();
         verifyNoMoreInteractions(sieveMailAdapter);
     }
@@ -150,9 +153,10 @@ public class VacationTest {
 
         JUnitUtils.interpret(sieveMailAdapter, script);
 
-        verify(sieveMailAdapter, times(2)).setContext(any(SieveContext.class));
+        verify(sieveMailAdapter).setContext(any(SieveContext.class));
+        verify(sieveMailAdapter).setContext(isNull(SieveContext.class));
         verify(sieveMailAdapter).addAction(ActionVacation.builder().reason("reason").from("benwa@apache.org").build());
-        verify(sieveMailAdapter, times(2)).addAction(any(ActionKeep.class));
+        verify(sieveMailAdapter).addAction(any(ActionKeep.class));
         verify(sieveMailAdapter).executeActions();
         verifyNoMoreInteractions(sieveMailAdapter);
     }
@@ -164,9 +168,10 @@ public class VacationTest {
 
         JUnitUtils.interpret(sieveMailAdapter, script);
 
-        verify(sieveMailAdapter, times(2)).setContext(any(SieveContext.class));
+        verify(sieveMailAdapter).setContext(any(SieveContext.class));
+        verify(sieveMailAdapter).setContext(isNull(SieveContext.class));
         verify(sieveMailAdapter).addAction(ActionVacation.builder().reason("reason").build());
-        verify(sieveMailAdapter, times(2)).addAction(any(ActionKeep.class));
+        verify(sieveMailAdapter).addAction(any(ActionKeep.class));
         verify(sieveMailAdapter).executeActions();
         verifyNoMoreInteractions(sieveMailAdapter);
     }
@@ -177,9 +182,10 @@ public class VacationTest {
 
         JUnitUtils.interpret(sieveMailAdapter, script);
 
-        verify(sieveMailAdapter, times(2)).setContext(any(SieveContext.class));
+        verify(sieveMailAdapter).setContext(any(SieveContext.class));
+        verify(sieveMailAdapter).setContext(isNull(SieveContext.class));
         verify(sieveMailAdapter).addAction(ActionVacation.builder().mime("reason").build());
-        verify(sieveMailAdapter, times(2)).addAction(any(ActionKeep.class));
+        verify(sieveMailAdapter).addAction(any(ActionKeep.class));
         verify(sieveMailAdapter).executeActions();
         verifyNoMoreInteractions(sieveMailAdapter);
     }
@@ -190,9 +196,10 @@ public class VacationTest {
 
         JUnitUtils.interpret(sieveMailAdapter, script);
 
-        verify(sieveMailAdapter, times(2)).setContext(any(SieveContext.class));
+        verify(sieveMailAdapter).setContext(any(SieveContext.class));
+        verify(sieveMailAdapter).setContext(isNull(SieveContext.class));
         verify(sieveMailAdapter).addAction(ActionVacation.builder().reason("reason").handle("plop").build());
-        verify(sieveMailAdapter, times(2)).addAction(any(ActionKeep.class));
+        verify(sieveMailAdapter).addAction(any(ActionKeep.class));
         verify(sieveMailAdapter).executeActions();
         verifyNoMoreInteractions(sieveMailAdapter);
     }
@@ -225,9 +232,10 @@ public class VacationTest {
 
         JUnitUtils.interpret(sieveMailAdapter, script);
 
-        verify(sieveMailAdapter, times(2)).setContext(any(SieveContext.class));
+        verify(sieveMailAdapter).setContext(any(SieveContext.class));
+        verify(sieveMailAdapter).setContext(isNull(SieveContext.class));
         verify(sieveMailAdapter).addAction(ActionVacation.builder().reason("reason").build());
-        verify(sieveMailAdapter, times(2)).addAction(any(ActionKeep.class));
+        verify(sieveMailAdapter).addAction(any(ActionKeep.class));
         verify(sieveMailAdapter).executeActions();
         verifyNoMoreInteractions(sieveMailAdapter);
     }

--- a/pom.xml
+++ b/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.apache</groupId>
         <artifactId>apache</artifactId>
-        <version>18</version>
+        <version>21</version>
         <relativePath />
     </parent>
 

--- a/pom.xml
+++ b/pom.xml
@@ -73,11 +73,6 @@
         <!-- Overridding this value allows single set of loopback settings to be maintained -->
         <james.www.id>jsieve-website</james.www.id>
 
-        <javax.mail.groupId>org.apache.geronimo.javamail</javax.mail.groupId>
-        <javax.mail.artifactId>geronimo-javamail_1.4_mail</javax.mail.artifactId>
-        <javax.activation.groupId>org.apache.geronimo.specs</javax.activation.groupId>
-        <javax.activation.artifactId>geronimo-activation_1.1_spec</javax.activation.artifactId>
-
         <target.jdk>1.6</target.jdk>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
@@ -86,8 +81,6 @@
         <log4j.version>2.12.1</log4j.version>
         <mail.version>1.4.4</mail.version>
         <activation.version>1.1.1</activation.version>
-        <geronimo-activation.version>1.1</geronimo-activation.version>
-        <geronimo-javamail.version>1.8.3</geronimo-javamail.version>
         <commons-io.version>2.1</commons-io.version>
         <mockito-core.version>1.9.0</mockito-core.version>
         <assertj.version>1.7.1</assertj.version>
@@ -182,16 +175,6 @@
                 <groupId>javax.inject</groupId>
                 <artifactId>javax.inject</artifactId>
                 <version>1</version>
-            </dependency>
-            <dependency>
-                <groupId>org.apache.geronimo.specs</groupId>
-                <artifactId>geronimo-activation_1.1_spec</artifactId>
-                <version>${geronimo-activation.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.apache.geronimo.javamail</groupId>
-                <artifactId>geronimo-javamail_1.4_mail</artifactId>
-                <version>${geronimo-javamail.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.mockito</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -82,7 +82,7 @@
         <mail.version>1.4.7</mail.version>
         <activation.version>1.1.1</activation.version>
         <commons-io.version>2.1</commons-io.version>
-        <mockito-core.version>1.9.0</mockito-core.version>
+        <mockito-core.version>3.0.0</mockito-core.version>
         <assertj.version>1.7.1</assertj.version>
         <guava.version>18.0</guava.version>
         <mime4j.version>0.8.3</mime4j.version>

--- a/pom.xml
+++ b/pom.xml
@@ -79,7 +79,7 @@
         <junit.version>4.12</junit.version>
         <jmock.version>1.2.0</jmock.version>
         <log4j.version>2.12.1</log4j.version>
-        <mail.version>1.4.4</mail.version>
+        <mail.version>1.4.7</mail.version>
         <activation.version>1.1.1</activation.version>
         <commons-io.version>2.1</commons-io.version>
         <mockito-core.version>1.9.0</mockito-core.version>

--- a/pom.xml
+++ b/pom.xml
@@ -83,7 +83,7 @@
 
         <junit.version>4.12</junit.version>
         <jmock.version>1.2.0</jmock.version>
-        <log4j.version>1.2.14</log4j.version>
+        <log4j.version>2.12.1</log4j.version>
         <mail.version>1.4.4</mail.version>
         <activation.version>1.1.1</activation.version>
         <geronimo-activation.version>1.1</geronimo-activation.version>
@@ -141,8 +141,8 @@
                         <artifactId>logkit</artifactId>
                     </exclusion>
                     <exclusion>
-                        <groupId>log4j</groupId>
-                        <artifactId>log4j</artifactId>
+                        <groupId>org.apache.logging.log4j</groupId>
+                        <artifactId>log4j-core</artifactId>
                     </exclusion>
                     <exclusion>
                         <groupId>javax.servlet</groupId>
@@ -163,8 +163,8 @@
                 <scope>test</scope>
             </dependency>
             <dependency>
-                <groupId>log4j</groupId>
-                <artifactId>log4j</artifactId>
+                <groupId>org.apache.logging.log4j</groupId>
+                <artifactId>log4j-core</artifactId>
                 <version>${log4j.version}</version>
                 <scope>test</scope>
             </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -231,7 +231,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <version>3.0</version>
+                <version>3.8.1</version>
                 <configuration>
                     <optimize>true</optimize>
                     <source>${target.jdk}</source>

--- a/pom.xml
+++ b/pom.xml
@@ -92,7 +92,7 @@
         <mockito-core.version>1.9.0</mockito-core.version>
         <assertj.version>1.7.1</assertj.version>
         <guava.version>18.0</guava.version>
-        <mime4j.version>0.8.1</mime4j.version>
+        <mime4j.version>0.8.3</mime4j.version>
     </properties>
 
     <dependencyManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -81,7 +81,7 @@
         <target.jdk>1.6</target.jdk>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
-        <junit.version>4.10</junit.version>
+        <junit.version>4.12</junit.version>
         <jmock.version>1.2.0</jmock.version>
         <log4j.version>1.2.14</log4j.version>
         <mail.version>1.4.4</mail.version>

--- a/pom.xml
+++ b/pom.xml
@@ -221,6 +221,7 @@
             <plugin>
                 <groupId>org.apache.rat</groupId>
                 <artifactId>apache-rat-plugin</artifactId>
+                <version>0.13</version>
                 <configuration>
                     <excludes>
                         <exclude>**/*help.txt</exclude>

--- a/pom.xml
+++ b/pom.xml
@@ -130,7 +130,7 @@
             <dependency>
                 <groupId>commons-logging</groupId>
                 <artifactId>commons-logging</artifactId>
-                <version>1.1.1</version>
+                <version>1.2</version>
                 <exclusions>
                     <exclusion>
                         <groupId>avalon-framework</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -84,7 +84,7 @@
         <commons-io.version>2.1</commons-io.version>
         <mockito-core.version>3.0.0</mockito-core.version>
         <assertj.version>1.7.1</assertj.version>
-        <guava.version>18.0</guava.version>
+        <guava.version>25.1-jre</guava.version>
         <mime4j.version>0.8.3</mime4j.version>
     </properties>
 

--- a/pom.xml
+++ b/pom.xml
@@ -215,7 +215,7 @@
             <plugin>
                 <groupId>org.apache.felix</groupId>
                 <artifactId>maven-bundle-plugin</artifactId>
-                <version>2.3.7</version>
+                <version>4.2.1</version>
                 <extensions>true</extensions>
             </plugin>
             <plugin>

--- a/util/pom.xml
+++ b/util/pom.xml
@@ -76,13 +76,13 @@
         </dependency>
 
         <dependency>
-            <groupId>${javax.mail.groupId}</groupId>
-            <artifactId>${javax.mail.artifactId}</artifactId>
+            <groupId>javax.mail</groupId>
+            <artifactId>mail</artifactId>
         </dependency>
 
         <dependency>
-            <groupId>${javax.activation.groupId}</groupId>
-            <artifactId>${javax.activation.artifactId}</artifactId>
+            <groupId>javax.activation</groupId>
+            <artifactId>activation</artifactId>
         </dependency>
 
         <dependency>

--- a/util/pom.xml
+++ b/util/pom.xml
@@ -70,8 +70,8 @@
         </dependency>
 
         <dependency>
-            <groupId>log4j</groupId>
-            <artifactId>log4j</artifactId>
+            <groupId>org.apache.logging.log4j</groupId>
+            <artifactId>log4j-core</artifactId>
             <scope>test</scope>
         </dependency>
 


### PR DESCRIPTION
Comments:
* mock:mock -> there is a new version which is org.jmock:mock. But the syntax is completely different. Seemed to painful to migrate, not worth the time investment for now.
* assertj-core -> need to target jdk 1.8 if we want to upgrade this lib